### PR TITLE
Add link to https://k8s.dev/ on the page https://kubernetes.io/community/

### DIFF
--- a/content/en/community/_index.html
+++ b/content/en/community/_index.html
@@ -18,7 +18,7 @@ cid: community
 </div>
 
 <div class="community__navbar">
-
+<a href="https://www.kubernetes.dev/">Contributor Community</a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 <a href="#values">Community Values</a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 <a href="#conduct">Code of conduct </a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
 <a href="#videos">Videos</a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;


### PR DESCRIPTION
Did not know where to place the Contributor Community link to https://www.kubernetes.dev/
Hopefully, this is what was envisioned in -
https://github.com/kubernetes/contributor-site/issues/202

Description: Added a link to https://www.kubernetes.dev/
using the text -
Contributor Community
on this page -
https://kubernetes.io/community
